### PR TITLE
feat: small changes to support botfront in model/train endpoint

### DIFF
--- a/rasa/shared/core/domain.py
+++ b/rasa/shared/core/domain.py
@@ -200,6 +200,15 @@ class Domain:
         Returns:
             The instantiated `Domain` object.
         """
+        
+        # Teemu Hirsimäki 14.10.2021: When training data comes through
+        # model/train endpoint, rasa stores data in a single file with keys such
+        # as (domain, stories, nlu, config). Fetch domain data from domain key
+        # if it exist.
+        domain = data.get('domain')
+        if domain is not None:
+            data = domain
+            
         responses = data.get(KEY_RESPONSES, {})
         slots = cls.collect_slots(data.get(KEY_SLOTS, {}))
         additional_arguments = data.get("config", {})

--- a/rasa/shared/nlu/training_data/schemas/responses.yml
+++ b/rasa/shared/nlu/training_data/schemas/responses.yml
@@ -12,6 +12,8 @@ schema;responses:
         required: True
         allowempty: False
         mapping:
+          language:
+            type: "str"
           text:
             type: "str"
           image:


### PR DESCRIPTION
Small changes to support model/train call from Botfront
- Added language key to responses schema
- Fetch domain data from domain dict key in training