### PR TITLE
storyt test modifications

### DIFF
--- a/rasa/shared/core/events.py
+++ b/rasa/shared/core/events.py
@@ -872,6 +872,7 @@ class BotUttered(SkipEventInMDStoryMixin):
         m = self.data.copy()
         m["text"] = self.text
         m["timestamp"] = self.timestamp
+        m["metadata"] = self.metadata  # bf mod: pass metadata in bot message
         m.update(self.metadata)
 
         if m.get("image") == m.get("attachment"):

--- a/rasa_addons/core/channels/bot_regression_test.py
+++ b/rasa_addons/core/channels/bot_regression_test.py
@@ -135,7 +135,14 @@ class BotRegressionTestInput(RestInput):
             "actual": [],
             "steps": [],
         }
+        previous_step = {}
         for unformatted_actual_step in actual_steps:
+            current_template = unformatted_actual_step.get('metadata', {}).get('template_name')
+            previous_template = previous_step.get('metadata', {}).get('template_name')
+            if current_template and previous_template:
+                if current_template == previous_template and current_template[0:6] == 'utter_':
+                    continue
+            previous_step = unformatted_actual_step
             actual_step = self.format_as_step(unformatted_actual_step)
             match_index = self.get_index_of_step(actual_step, expected_steps_remaining)
             if match_index is None:


### PR DESCRIPTION
Necessary changes to addons and rasa in order to support story testing from botfront.

Added:
- metadata key to bot message template to support story testing functionality (as it was done in rasa-for-botfront).
- logic to story test comparator which handles case where there is multiple consecutive bot messages in between user messages.

